### PR TITLE
Phase 1+2: 最寄ライン / 画面常時ON / 進行方位更新 + 音声ガイダンス / 設定永続化 / 自動復帰

### DIFF
--- a/タスクリスト.md
+++ b/タスクリスト.md
@@ -62,8 +62,8 @@ StraightBar Lite – Visual タスクリスト（v0.2.3-robust基準）
 - [x] 最寄ラインの実装
 - [x] 画面常時ON（Wake Lock）
 - [x] 進行方位の更新（heading/差分方位）
-- [ ] 音声ガイダンス（閾値/ヒステリシス/クールダウン）
-- [ ] 設定永続化（localStorage）
-- [ ] 自動復帰（watch→polling→watch）
+- [x] 音声ガイダンス（閾値/ヒステリシス/クールダウン）
+- [x] 設定永続化（localStorage）
+- [x] 自動復帰（watch→polling→watch）
 
 


### PR DESCRIPTION
概要:
- フェーズ1とフェーズ2のタスクを実装しました。

含まれる変更:
- 最寄ライン: 現在位置から最も近い並行ラインへスナップ（A/B有効かつAB>=5m）
- 画面常時ON: Wake Lock APIに対応（ON/OFFトグル、可視状態で自動再取得）。非対応端末は案内表示
- 進行方位更新: geolocation.heading または直近座標差から方位角(°)を計算（低速時は抑制）
- 音声ガイダンス: 閾値±0.30m・ヒステリシス±0.25/±0.35・クールダウン2.5秒
- 設定永続化: 作業幅、ライン番号、音声ON/OFF、画面常時ON希望をlocalStorageに保存/復元
- 自動復帰: watch停止→polling、pollingで10回連続成功後にwatchへ自動再開
- ラベル統一: 「針路」→「進行方位」

主なファイル:
- app.js: 機能本体
- index.html/README.md/USAGE.md/タスクリスト.md: 表示文言・ドキュメント

テスト観点:
- A/B設定後、「最寄ライン」でターゲットが最寄ラインに切り替わる
- 「画面常時ON」をONでスリープしない（非対応端末は案内）
- 進行方位(°)が移動とともに自然に変化（低速時は更新抑制）
- 音声ガイダンスの連呼抑制（クールダウン/ヒステリシス）
- 再読み込み後に作業幅/ライン/音声/画面常時ONの希望が復元
- 更新停止→polling→安定後にwatchへ自動復帰

その他:
- 既存の挙動に影響を与えないようガードを追加（AB<5m時の扱い等）

レビューお願いします。
