### PR TITLE
fix: AB距離<5m時のB無効化と早期リターン（誤表示防止）+ README v0.2.5整備

### DIFF
--- a/app.js
+++ b/app.js
@@ -68,7 +68,22 @@ function vecLen(v){return Math.hypot(v.x,v.y)} function vecNorm(v){const L=vecLe
 function dot(a,b){return a.x*b.x+a.y*b.y}
 
 function setAFrom(lat,lon){const lat0=lat,lon0=lon;A={xy:{x:0,y:0},deg:{lat,lon},lat0,lon0};B=null;el.setB.disabled=false;el.hint.textContent='A点設定済。B点を設定してください。';el.distInfo.textContent='';log(`A点設定: ${lat.toFixed(7)}, ${lon.toFixed(7)}`)}
-function setBFrom(lat,lon){if(!A)return;const xy=degToMeters(lat,lon,A.lat0,A.lon0);B={xy,deg:{lat,lon},lat0:A.lat0,lon0:A.lon0};const dist=vecLen(xy);el.distInfo.textContent=`AB距離: ${dist.toFixed(2)} m`;if(dist<5){alert(`B点までの距離が短すぎます (${dist.toFixed(2)} m)。10〜30m離して設定してください。`)}el.hint.textContent='ABライン設定OK。最寄ラインへスナップ可。';log(`B点設定: ${lat.toFixed(7)}, ${lon.toFixed(7)} (距離 ${dist.toFixed(2)} m)`)}
+function setBFrom(lat,lon){
+  if(!A)return;
+  const xy=degToMeters(lat,lon,A.lat0,A.lon0);
+  const dist=vecLen(xy);
+  el.distInfo.textContent=`AB距離: ${dist.toFixed(2)} m`;
+  if(dist<5){
+    B=null; // 無効化して再設定待ち
+    el.setB.disabled=false;
+    el.hint.textContent='B点が近すぎます。10m以上離して再設定してください';
+    log(`B点拒否(近すぎ): ${lat.toFixed(7)}, ${lon.toFixed(7)} (距離 ${dist.toFixed(2)} m)`);
+    return;
+  }
+  B={xy,deg:{lat,lon},lat0:A.lat0,lon0:A.lon0};
+  el.hint.textContent='ABライン設定OK。最寄ラインへスナップ可。';
+  log(`B点設定: ${lat.toFixed(7)}, ${lon.toFixed(7)} (距離 ${dist.toFixed(2)} m)`);
+}
 
 function getRotatedDirN(){
   if(!A||!B) return {x:0,y:1};


### PR DESCRIPTION
内容:\n- AB距離<5mの場合はBを無効化し、ヒント更新の上で早期リターン（誤った横ズレ表示を防止）\n- READMEをv0.2.5(Drive/Calibration)の内容に更新済み\n\n確認観点:\n- AB<5mでBが残らず、再設定を促す文言が表示される\n- 正常ケース(AB>=5m)で従来どおりABが確定\n- READMEが最新仕様を反映\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents setting point B when too close to point A (<5 m), ensuring consistent state and accurate AB line setup.
  * Keeps the “Set B” action available after a rejected attempt and continues to display distance information.

* **New Features**
  * Replaces pop-up alerts with inline UI messaging for clearer guidance when B is too close.
  * Provides updated on-screen hints confirming successful AB setup and nearest-line snapping when distance is sufficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->