### PR TITLE
feat(simplify v0.2.6): UI/機能の大幅簡素化（Drive/自動キャリブ等の撤去・バー表示一本化）

### DIFF
--- a/app.js
+++ b/app.js
@@ -68,7 +68,22 @@ function vecLen(v){return Math.hypot(v.x,v.y)} function vecNorm(v){const L=vecLe
 function dot(a,b){return a.x*b.x+a.y*b.y}
 
 function setAFrom(lat,lon){const lat0=lat,lon0=lon;A={xy:{x:0,y:0},deg:{lat,lon},lat0,lon0};B=null;el.setB.disabled=false;el.hint.textContent='A点設定済。B点を設定してください。';el.distInfo.textContent='';log(`A点設定: ${lat.toFixed(7)}, ${lon.toFixed(7)}`)}
-function setBFrom(lat,lon){if(!A)return;const xy=degToMeters(lat,lon,A.lat0,A.lon0);B={xy,deg:{lat,lon},lat0:A.lat0,lon0:A.lon0};const dist=vecLen(xy);el.distInfo.textContent=`AB距離: ${dist.toFixed(2)} m`;if(dist<5){alert(`B点までの距離が短すぎます (${dist.toFixed(2)} m)。10〜30m離して設定してください。`)}el.hint.textContent='ABライン設定OK。最寄ラインへスナップ可。';log(`B点設定: ${lat.toFixed(7)}, ${lon.toFixed(7)} (距離 ${dist.toFixed(2)} m)`)}
+function setBFrom(lat,lon){
+  if(!A)return;
+  const xy=degToMeters(lat,lon,A.lat0,A.lon0);
+  const dist=vecLen(xy);
+  el.distInfo.textContent=`AB距離: ${dist.toFixed(2)} m`;
+  if(dist<5){
+    B=null; // 無効化して再設定待ち
+    el.setB.disabled=false;
+    el.hint.textContent='B点が近すぎます。10m以上離して再設定してください';
+    log(`B点拒否(近すぎ): ${lat.toFixed(7)}, ${lon.toFixed(7)} (距離 ${dist.toFixed(2)} m)`);
+    return;
+  }
+  B={xy,deg:{lat,lon},lat0:A.lat0,lon0:A.lon0};
+  el.hint.textContent='ABライン設定OK。最寄ラインへスナップ可。';
+  log(`B点設定: ${lat.toFixed(7)}, ${lon.toFixed(7)} (距離 ${dist.toFixed(2)} m)`);
+}
 
 function getRotatedDirN(){
   if(!A||!B) return {x:0,y:1};

--- a/index.html
+++ b/index.html
@@ -14,9 +14,7 @@
       GPS: <span id="gpsStatus">待機中</span>
       / 精度: <span id="acc">-</span>m
       / 速度: <span id="spd">-</span>km/h
-      / 進行方位: <span id="hdg">-</span>°
       / 更新: <span id="hz">-</span>Hz
-      / モード: <span id="mode">watch</span>
     </div>
   </header>
 
@@ -27,7 +25,6 @@
       <div id="unit">m</div>
       <div id="hint">A/Bラインを設定してください</div>
       <div id="distInfo" class="note"></div>
-      <div id="qa" class="note"></div>
       <div id="warn" class="warn" style="display:none;">⚠ 3秒以上位置更新がありません（権限/電波/屋外条件をご確認ください）</div>
     </section>
 
@@ -45,8 +42,6 @@
         <button id="stopBtn" disabled>停止</button>
         <button id="wakelockBtn">画面常時ON</button>
         <button id="speechBtn">音声: OFF</button>
-        <button id="driveBtn">Driveモード: OFF</button>
-        <button id="presetBtn">しきい値: Wide</button>
       </div>
       <div class="row">
         <button id="setA">A点 設定</button>
@@ -56,13 +51,10 @@
       </div>
       <div class="row">
         <label>作業幅 (m): <input id="swath" type="number" min="0.1" step="0.1" value="2.0"></label>
-        <button id="prevLine">← 1本前へ</button>
-        <button id="nextLine">1本次へ →</button>
-        <button id="snapNearest">最寄ライン</button>
+        <button id="prevLine">1本左へ</button>
+        <button id="nextLine">1本右へ</button>
       </div>
       <div class="row">
-        <button id="darkModeBtn">夜間モード</button>
-        <button id="resetKalman">フィルタリセット</button>
         <button id="exportState">状態保存</button>
       </div>
     </section>


### PR DESCRIPTION
概要:\n- 画面簡素化: ヘッダーの進行方位/モードを削除、操作ボタンの整理（最寄/夜間/フィルタ削除、左右ボタン表記変更）\n- 描画: Driveモード矢印/背景色/キャロットを撤去し、中央バー表示に一本化\n- ロジック: 自動キャリブ（quick）、自動回転補正、品質HUDを撤去。crossTrackはシンプル版に\n- 維持: A/B設定、作業幅、1本左/右、ここをゼロ、画面常時ON、音声（任意で今後削除可能）\n\n確認観点:\n- 余計な要素がなく、AB設定→表示→左右ボタン/ここをゼロの最小動線になっている\n- 横ズレ表示がバーで明瞭。文言が「1本左へ/1本右へ」になっている\n- 進行方位/モード表示が消えている\n