### PR TITLE
feat(ui): 画面常時ONを非表示／ここをゼロと作業幅を同一行に配置／バージョン表記をv0.2.6-robustへ更新

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,14 +5,13 @@ start:document.getElementById('startBtn'),stop:document.getElementById('stopBtn'
 setA:document.getElementById('setA'),setB:document.getElementById('setB'),clearAB:document.getElementById('clearAB'),swath:document.getElementById('swath'),
 prevLine:document.getElementById('prevLine'),nextLine:document.getElementById('nextLine'),
 log:document.getElementById('log'),viz:document.getElementById('viz'),vizRange:document.getElementById('vizRange'), warn:document.getElementById('warn'),
-wakelockBtn:document.getElementById('wakelockBtn'), zeroNow:document.getElementById('zeroNow')};
+zeroNow:document.getElementById('zeroNow')};
 
 const ctx=el.viz.getContext('2d');
 function resizeCanvas(){const rect=el.viz.getBoundingClientRect();el.viz.width=Math.max(600,Math.floor(rect.width*devicePixelRatio));el.viz.height=Math.floor(260*devicePixelRatio)}
 resizeCanvas();addEventListener('resize',resizeCanvas);
 
 let watchId=null,pollId=null,last=null;
-let wakeLock=null;
 let A=null,B=null,swathWidth=parseFloat(localStorage.getItem('swathWidth')||el.swath.value)||2.0,currentLineIndex=parseInt(localStorage.getItem('lineIndex')||'0',10)||0;
 let tickCount=0,lastHzAt=performance.now(), lastUpdateAt=0;
 const R=6378137,toRad=d=>d*Math.PI/180;
@@ -169,26 +168,7 @@ document.getElementById('zeroNow').addEventListener('click', ()=>{
    if(last&&A){const xy=degToMeters(last.lat,last.lon,A.lat0,A.lon0);const ct=crossTrack(xy);const offset=(currentLineIndex*swathWidth)-(ct?ct.perp:0);drawViz(offset);}else{drawViz(0);} 
  });
 
- // Wake Lock（画面常時ON）
- async function requestWakeLock(){
-   if(!('wakeLock' in navigator)){ log('wakeLock unsupported'); alert('画面常時ONは端末/ブラウザ非対応です。自動ロック設定をご確認ください。'); return; }
-   try{
-     wakeLock=await navigator.wakeLock.request('screen');
-     el.wakelockBtn.textContent='画面常時ON: ON';
-     wakeLock.addEventListener('release',()=>{ el.wakelockBtn.textContent='画面常時ON'; wakeLock=null; });
-   }catch(e){ log('wakeLock error: '+e.message); }
- }
- async function toggleWakeLock(){
-   try{
-     if(wakeLock){ await wakeLock.release(); wakeLock=null; el.wakelockBtn.textContent='画面常時ON'; }
-     else{ await requestWakeLock(); }
-   }catch(e){ log('wakeLock toggle error: '+e.message); }
- }
- el.wakelockBtn.addEventListener('click', ()=>{ toggleWakeLock(); localStorage.setItem('wakePref', el.wakelockBtn.textContent.includes('ON')?'1':'0'); });
- document.addEventListener('visibilitychange', ()=>{ if(document.visibilityState==='visible' && wakeLock==null && localStorage.getItem('wakePref')==='1'){ requestWakeLock(); }});
-
  // 初期UI反映
- if(localStorage.getItem('wakePref')==='1'){ requestWakeLock(); }
  el.swath.value=String(swathWidth);
  if(Number.isFinite(currentLineIndex)) try{ localStorage.setItem('lineIndex', String(currentLineIndex)); }catch(_){ }
  drawViz(0);

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
   <meta charset="utf-8">
-  <title>StraightBar Lite – Visual v0.2.3-robust</title>
+  <title>StraightBar Lite – Visual v0.2.6-robust</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <link rel="manifest" href="manifest.json">
   <link rel="stylesheet" href="style.css">
@@ -40,16 +40,17 @@
       <div class="row">
         <button id="startBtn">計測開始</button>
         <button id="stopBtn" disabled>停止</button>
-        <button id="wakelockBtn">画面常時ON</button>
       </div>
       <div class="row">
         <button id="setA">A点 設定</button>
         <button id="setB" disabled>B点 設定</button>
         <button id="clearAB">A/Bクリア</button>
-        <button id="zeroNow">ここをゼロ</button>
       </div>
       <div class="row">
+        <button id="zeroNow">ここをゼロ</button>
         <label>作業幅 (m): <input id="swath" type="number" min="0.1" step="0.1" value="2.0"></label>
+      </div>
+      <div class="row">
         <button id="prevLine">1本左へ</button>
         <button id="nextLine">1本右へ</button>
       </div>
@@ -59,7 +60,7 @@
   </main>
 
   <footer>
-    <small>※スマホ内蔵GPSは数mブレます。広い作業幅向けの“目安”用途。 v0.2.3-robust（SWなし, nocache）</small>
+    <small>※スマホ内蔵GPSは数mブレます。広い作業幅向けの“目安”用途。 v0.2.6-robust（SWなし, nocache）</small>
   </footer>
 
   <script src="app.js"></script>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the Wake Lock control and related behavior.
  * Reorganized layout: moved 作業幅 (swath) to its own row; relocated PrevLine/NextLine to a separate row after swath; repositioned ZeroNow within A/B controls.
* **Chores**
  * Updated app version to v0.2.6-robust in title and footer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->